### PR TITLE
Allow specifying SSLCertificateChainFile for Apache

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ nextcloud_tls_dhparam: "/etc/ssl/dhparam.pem"
 # nextcloud_tls_cert_method: "self-signed" | "signed" | "cerbot" (letsencrypt) | "installed"
 # nextcloud_tls_cert: /path/to/cert
 # nextcloud_tls_cert_key: /path/to/cert/key
+# nextcloud_tls_cert_chain: /path/to/cert/chain
 # nextcloud_tls_src_cert: /path/to/cert
 # nextcloud_tls_src_cert_key: /path/to/cert/key
 

--- a/tasks/tls_installed.yml
+++ b/tasks/tls_installed.yml
@@ -1,6 +1,8 @@
 ---
 - set_fact: nextcloud_tls_cert_file="{{ nextcloud_tls_cert }}"
 - set_fact: nextcloud_tls_cert_key_file="{{ nextcloud_tls_cert_key }}"
+- set_fact: nextcloud_tls_cert_chain_file="{{ nextcloud_tls_cert_chain }}"
+  when: nextcloud_tls_cert_chain is defined
 # - name: "[INSTALLED TLS] - check TLS certicate permissions"
   # file:
     # path: "{{ nextcloud_tls_cert_file }}"

--- a/templates/apache_nc.j2
+++ b/templates/apache_nc.j2
@@ -29,6 +29,9 @@
   SSLEngine on
   SSLCertificateFile      {{ nextcloud_tls_cert_file }}
   SSLCertificateKeyFile   {{ nextcloud_tls_cert_key_file }}
+  {% if nextcloud_tls_cert_chain_file is defined %}
+  SSLCertificateChainFile {{ nextcloud_tls_cert_chain_file }}
+  {% endif %}
 
   <IfModule mod_headers.c>
   # HSTS (mod_headers is required) (15768000 seconds = 6 months)


### PR DESCRIPTION
This is required for example to use LetsEncrypt certificates which need the whole chain installed.