### PR TITLE
Allow specifying nextcloud_os_user to create a user with home folder

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ nextcloud_data_dir: "/var/ncdata"
 nextcloud_admin_name: "admin"
 # nextcloud_admin_pwd: "secret"
 nextcloud_dl_url: "https://download.nextcloud.com/server/releases"
+# Set a username here if a user with home folder should be created
+# This then allows setting nextcloud_webroot and/or nextcloud_data_dir
+# under the user home folder
+#nextcloud_os_user: nextcloud
 
 # [DATABASE]
 # nextcloud_db_backend: "mysql"/"mariadb" | "pgsql"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,9 @@
 - include: tasks/setup_env.yml
   # load os specific variables
 
+- include: tasks/user.yml
+  when: nextcloud_os_user is defined
+
 - name: Verify permission for installed TLS certificates
   include: tasks/tls_installed.yml
   when: nextcloud_tls_cert_method == "installed"

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,7 @@
+---
+- name: Nextcloud user
+  user: name="{{ nextcloud_os_user }}" state=present
+- name: Ensure www-data member of Nextcloud user group
+  user: name={{ websrv_user }} append=yes groups="{{ nextcloud_os_user }}" state=present
+- name: Make Nextcloud user home non-world readable
+  file: path=/home/{{ nextcloud_os_user }} mode=0750 state=directory


### PR DESCRIPTION
This allows then placing webroot and data dir under the created user.