### PR TITLE
Allow skipping of web and database server installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This role requires root access, so either configure it in your inventory files, 
 
 ## Role Variables
 
-Role's variables (and their default value):
+Role's variables (and their default values):
 
 ### Installation configuration
 > Source location will be calculated following channel, version and branch values.
@@ -58,6 +58,10 @@ The list of domains you will use to access the same Nextcloud instance.
 nextcloud_instance_name: "{{ nextcloud_trusted_domain | first }}"
 ```
 The name of the Nextcloud instance. By default, the first element in the list of trusted domains
+```YAML
+nextcloud_install_websrv: true
+```
+The webserver setup can be skipped if you have one installed already.
 ```YAML
 nextcloud_websrv: "apache2"
 ```
@@ -119,6 +123,10 @@ The Nextcloud instance's database user's password.
 If not defined by the user, a random password will be generated.
 
 ### TLS configuration
+```YAML
+nextcloud_install_tls: true
+```
+TLS setup can be skipped if you manage it separately (e.g. behind a reverse proxy).
 ```YAML
 nextcloud_tls_enforce: true
 ```
@@ -219,7 +227,7 @@ You must create first your certificates using a letsencrypt ACME client or an An
 
 then call _install_nextcloud_ by setting `nextcloud_tls_cert_method: "installed"`
 
-Here 2 examples for apache and nginx (because their have slightly different configuration)
+Here 2 examples for apache and nginx (because they have slightly different configurations)
 ```YAML
 ---
 - hosts: apache_server

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,9 @@ nextcloud_repository: "https://download.nextcloud.com/server"
 
 nextcloud_trusted_domain: ["{{ ansible_default_ipv4.address }}"]
 nextcloud_instance_name: "{{ nextcloud_trusted_domain | first }}"
+
 # nextcloud_websrv: "apache2" | "nginx"
+nextcloud_install_websrv: true
 nextcloud_websrv: "apache2"
 nextcloud_webroot: "/opt/nextcloud"
 nextcloud_data_dir: "/var/ncdata"
@@ -30,6 +32,7 @@ nextcloud_db_admin: "ncadmin"
 # nextcloud_db_pwd: "secret"
 
 # [TLS]
+nextcloud_install_tls: true
 nextcloud_tls_enforce: true
 nextcloud_force_strong_apache_ssl: true
 nextcloud_tls_cert_method: "self-signed"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,31 +5,31 @@
 
 - name: Verify permission for installed TLS certificates
   include: tasks/tls_installed.yml
-  when: nextcloud_tls_cert_method == "installed"
+  when: nextcloud_install_tls and nextcloud_tls_cert_method == "installed"
 
 - name: Install given signed certificates
   include: tasks/tls_signed.yml
-  when: nextcloud_tls_cert_method == "signed"
+  when: nextcloud_install_tls and nextcloud_tls_cert_method == "signed"
 
 - name: configure self signed TLS certificates
   include: tasks/tls_selfsigned.yml
-  when: nextcloud_tls_cert_method == "self-signed"
+  when: nextcloud_install_tls and nextcloud_tls_cert_method == "self-signed"
 
 - name: Configure Nginx web server.
   include: tasks/http_nginx.yml
-  when: nextcloud_websrv == "nginx"
+  when: nextcloud_install_websrv and nextcloud_websrv in ["nginx"]
 
 - name: Configure Apache web server
   include: tasks/http_apache.yml
-  when: nextcloud_websrv in ["apache", "apache2"]
+  when: nextcloud_install_websrv and nextcloud_websrv in ["apache", "apache2"]
 
 - name: Configure {{ nextcloud_db_backend }} database
   include: tasks/db_mysql.yml
-  when: nextcloud_db_backend in ["mysql", "mariadb"] and nextcloud_install_db == true
+  when: nextcloud_install_db and nextcloud_db_backend in ["mysql", "mariadb"]
 
 - name: Configure PostgreSQL database
   include: tasks/db_postgresql.yml
-  when: nextcloud_db_backend in ["pgsql"] and nextcloud_install_db == true
+  when: nextcloud_install_db and nextcloud_db_backend in ["pgsql"]
 
 - name: Check Nextcloud installed
   stat: "path={{ nextcloud_webroot }}/index.php"


### PR DESCRIPTION
This PR adds 2 extra options to skip webserver (and PHP) installation and TLS certificate management.

Just like the database installation can be skipped, this allows for the webserver and TLS part to be skipped.

I use this role in an environment that already has DB and reverse proxy set up, so there's no need for a duplicate installation.