### PR TITLE
Non TLS webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,13 @@ Force http to https.
 ```YAML
 nextcloud_force_strong_apache_ssl: true
 ```
-force strong ssl configuration in the virtualhost file
+Force strong ssl configuration in the virtualhost file.
+```YAML
+nextcloud_hsts: false
+```
+Set HTTP Strict-Transport-Security header (e.g. "max-age=15768000; includeSubDomains; preload").
+
+*(Before enabling HSTS, please read into this topic first)*
 ```YAML
 nextcloud_tls_cert_method: "self-signed"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ nextcloud_tls_enforce: true
 nextcloud_force_strong_apache_ssl: true
 nextcloud_tls_cert_method: "self-signed"
 nextcloud_tls_dhparam: "/etc/ssl/dhparam.pem"
+nextcloud_hsts: false
 # nextcloud_tls_cert_method: "self-signed" | "signed" | "installed"
 # nextcloud_tls_cert: /path/to/cert
 # nextcloud_tls_cert_key: /path/to/cert/key

--- a/tasks/http_apache.yml
+++ b/tasks/http_apache.yml
@@ -56,11 +56,11 @@
   template:
     dest: /etc/apache2/sites-available/nc_{{ nextcloud_instance_name }}.conf
     src: templates/apache_nc.j2
+  notify: reload apache
 
 - name: "[APACHE] -  Enable Nextcloud site in apache conf"
   file:
     path: /etc/apache2/sites-enabled/nc_{{ nextcloud_instance_name }}.conf
     src: /etc/apache2/sites-available/nc_{{ nextcloud_instance_name }}.conf
     state: link
-    # validate: "/usr/sbin/nginx -t #%s"
-  notify: restart apache
+  notify: reload apache

--- a/templates/apache_nc.j2
+++ b/templates/apache_nc.j2
@@ -1,4 +1,4 @@
-{% if nextcloud_tls_enforce %}
+{% if nextcloud_install_tls and nextcloud_tls_enforce %}
 {% for domain in nextcloud_trusted_domain %}
 <VirtualHost *:80>
   ServerName {{ domain }}
@@ -8,11 +8,9 @@
 {% else %}
 <VirtualHost *:80>
   ServerName {{ nextcloud_trusted_domain[0] }}
-{% if nextcloud_trusted_domain|length > 1 %}
-{% for index in range(1, nextcloud_trusted_domain|length -1) %}
+{% for index in range(1, nextcloud_trusted_domain|length) %}
   ServerAlias {{ nextcloud_trusted_domain[index]}}
 {% endfor %}
-{% endif %}
   DocumentRoot {{ nextcloud_webroot }}
   <Directory {{ nextcloud_webroot }}>
     Allow from all
@@ -31,27 +29,28 @@
 </VirtualHost>
 {% endif %}
 
-
+{% if nextcloud_install_tls %}
 <VirtualHost *:443>
   ServerName {{ nextcloud_trusted_domain[0] }}
-{% if nextcloud_trusted_domain|length > 1 %}
-{% for index in range(1, nextcloud_trusted_domain|length -1) %}
+{% for index in range(1, nextcloud_trusted_domain|length) %}
   ServerAlias {{ nextcloud_trusted_domain[index]}}
 {% endfor %}
-{% endif %}
   DocumentRoot {{ nextcloud_webroot }}
 
   SSLEngine on
   SSLCertificateFile      {{ nextcloud_tls_cert_file }}
   SSLCertificateKeyFile   {{ nextcloud_tls_cert_key_file }}
-  {% if nextcloud_tls_cert_chain_file is defined %}
+{% if nextcloud_tls_cert_chain_file is defined %}
   SSLCertificateChainFile {{ nextcloud_tls_cert_chain_file }}
-  {% endif %}
+{% endif %}
 
-  <IfModule mod_headers.c>
+  # <IfModule mod_headers.c>
   # HSTS (mod_headers is required) (15768000 seconds = 6 months)
-  Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
-  </IfModule>
+  # Before enabling Strict-Transport-Security headers please read into this
+  # topic first.
+  # Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
+  #</IfModule>
+
   <Directory {{ nextcloud_webroot }}>
     Allow from all
     Satisfy Any
@@ -67,8 +66,9 @@
 
   </Directory>
 </VirtualHost>
+{% endif %}
 
-{% if nextcloud_force_strong_apache_ssl %}
+{% if nextcloud_install_tls and nextcloud_force_strong_apache_ssl %}
 # intermediate configuration, tweak to your needs
 SSLProtocol             all -SSLv3
 SSLCipherSuite          ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS

--- a/templates/apache_nc.j2
+++ b/templates/apache_nc.j2
@@ -44,12 +44,11 @@
   SSLCertificateChainFile {{ nextcloud_tls_cert_chain_file }}
 {% endif %}
 
-  # <IfModule mod_headers.c>
-  # HSTS (mod_headers is required) (15768000 seconds = 6 months)
-  # Before enabling Strict-Transport-Security headers please read into this
-  # topic first.
-  # Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains; preload"
-  #</IfModule>
+{% if nextcloud_hsts is string %}
+  <IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "{{ nextcloud_hsts }}"
+  </IfModule>
+{% endif %}
 
   <Directory {{ nextcloud_webroot }}>
     Allow from all

--- a/templates/nginx_nc_root.j2
+++ b/templates/nginx_nc_root.j2
@@ -1,4 +1,4 @@
-{% if nextcloud_tls_enforce %}
+{% if nextcloud_install_tls and nextcloud_tls_enforce %}
 server {
     listen 80;
     server_name {{ nextcloud_trusted_domain | join(' ') }};
@@ -8,12 +8,13 @@ server {
 
 {% endif %}
 server {
-{% if not nextcloud_tls_enforce %}
-    listen 80;
-{% endif %}
-    listen 443 ssl;
     server_name {{ nextcloud_trusted_domain | join(' ') }};
 
+{% if not nextcloud_install_tls or not nextcloud_tls_enforce %}
+    listen 80;
+{% endif %}
+{% if nextcloud_install_tls %}
+    listen 443 ssl;
     ssl_certificate {{ nextcloud_tls_cert_file }};
     ssl_certificate_key {{ nextcloud_tls_cert_key_file }};
     ssl_session_timeout 1d;
@@ -32,8 +33,9 @@ server {
     # Add headers to serve security related headers
     # Before enabling Strict-Transport-Security headers please read into this
     # topic first.
-    add_header Strict-Transport-Security "max-age=15768000;
-    includeSubDomains; preload;";
+    # add_header Strict-Transport-Security "max-age=15768000;
+    # includeSubDomains; preload;";
+{% endif %}
     add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
@@ -94,7 +96,7 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
-        fastcgi_param HTTPS on;
+        fastcgi_param HTTPS $https if_not_empty;
         #Avoid sending the security headers twice
         fastcgi_param modHeadersAvailable true;
         fastcgi_param front_controller_active true;
@@ -115,10 +117,12 @@ server {
         add_header Cache-Control "public, max-age=7200";
         # Add headers to serve security related headers (It is intended to
         # have those duplicated to the ones above)
+{% if nextcloud_install_tls %}
         # Before enabling Strict-Transport-Security headers please read into
         # this topic first.
         # add_header Strict-Transport-Security "max-age=15768000;
         #  includeSubDomains; preload;";
+{% endif %}
         add_header X-Content-Type-Options nosniff;
         add_header X-Frame-Options "SAMEORIGIN";
         add_header X-XSS-Protection "1; mode=block";

--- a/templates/nginx_nc_root.j2
+++ b/templates/nginx_nc_root.j2
@@ -31,10 +31,9 @@ server {
     ssl_prefer_server_ciphers on;
 
     # Add headers to serve security related headers
-    # Before enabling Strict-Transport-Security headers please read into this
-    # topic first.
-    # add_header Strict-Transport-Security "max-age=15768000;
-    # includeSubDomains; preload;";
+{% if nextcloud_hsts is string %}
+    add_header Strict-Transport-Security "{{ nextcloud_hsts }}";
+{% endif %}
 {% endif %}
     add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options "SAMEORIGIN";
@@ -117,11 +116,8 @@ server {
         add_header Cache-Control "public, max-age=7200";
         # Add headers to serve security related headers (It is intended to
         # have those duplicated to the ones above)
-{% if nextcloud_install_tls %}
-        # Before enabling Strict-Transport-Security headers please read into
-        # this topic first.
-        # add_header Strict-Transport-Security "max-age=15768000;
-        #  includeSubDomains; preload;";
+{% if nextcloud_install_tls and nextcloud_hsts is string %}
+        add_header Strict-Transport-Security "{{ nextcloud_hsts }}";
 {% endif %}
         add_header X-Content-Type-Options nosniff;
         add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
What this PR contains:
- Allows the apache and nginx servers to be set up to not require TLS.
- Fixes a bug that wasn't adding all aliases to the apache configuration correctly (length-1 [here](https://github.com/aalaesar/install_nextcloud/pull/17/files#diff-7fbbb660a98bb360e8b59c996551b011L12)).
- Reload apache correctly after the configuration has changed.
- **HSTS option added!** ~I've commented out the HSTS code, as it can be dangerous if used without knowing what it does. **I'd highly suggest to add an option for this, as otherwise the configuration would always be overwriting the value!**~

@aalaesar Please check it out and then I'll think of how to add an appropriate entry to the reamde.

Fix #16 