### PR TITLE
Fix occ command

### DIFF
--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -40,15 +40,15 @@
   - name: "[NC] - Run occ installation command"
     become_user: "{{ websrv_user }}"
     command: >
-        php occ  maintenance:install
-        --database {{ nextcloud_tmp_backend }}
-        --database-host {{ nextcloud_db_host }}
-        --database-name {{ nextcloud_db_name }}
-        --database-user {{ nextcloud_db_admin }}
-        --database-pass {{ nextcloud_db_pwd }}
-        --admin-user {{ nextcloud_admin_name }}
-        --admin-pass {{ nextcloud_admin_pwd }}
-        --data-dir {{ nextcloud_data_dir }}
+        php occ maintenance:install
+        --database={{ nextcloud_tmp_backend }}
+        --database-host={{ nextcloud_db_host }}
+        --database-name={{ nextcloud_db_name }}
+        --database-user={{ nextcloud_db_admin }}
+        --database-pass={{ nextcloud_db_pwd }}
+        --admin-user={{ nextcloud_admin_name }}
+        --admin-pass={{ nextcloud_admin_pwd }}
+        --data-dir={{ nextcloud_data_dir }}
     args:
       chdir: "{{ nextcloud_webroot }}"
       creates: "{{ nextcloud_webroot }}/config/config.php"


### PR DESCRIPTION
Fix the occ command to allow any characters to be passed as parameters.

To pass quotes as a password, the variable must be defined properly:
`"i'm a password"` would be `nextcloud_admin_pwd: '\""I\''m a password\”"'`

The formatting may be a bit weird, but luckily it only needs to be set once 😉 
(if you have a password with quotes that is...)

Fix #7 