### PR TITLE
Prefixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,15 +174,15 @@ Defines various method for retrieving a TLS certificate.
 
 ### System configuration
 ```YAML
-websrv_user: "www-data"
+nextcloud_websrv_user: "www-data"
 ```
 system user for the http server
 ```YAML
-websrv_group: "www-data"
+nextcloud_websrv_group: "www-data"
 ```
 system group for the http server
 ```YAML
-mysql_root_pwd: "secret"
+nextcloud_mysql_root_pwd: "secret"
 ```
 root password for the mysql server
 
@@ -275,7 +275,7 @@ Here 2 examples for apache and nginx (because they have slightly different confi
      nextcloud_tls_cert_method: "installed"
      nextcloud_tls_cert: "/etc/nginx/certs/nextcloud.crt"
      nextcloud_tls_cert_key: "/etc/nginx/certs/nextcloud.key"
-     mysql_root_pwd: "42h2g2"
+     nextcloud_mysql_root_pwd: "42h2g2"
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,6 @@ nextcloud_hsts: false
 
 
 # [SYSTEM]
-websrv_user: "www-data"
-websrv_group: "www-data"
-#mysql_root_pwd: "secret"
+nextcloud_websrv_user: "www-data"
+nextcloud_websrv_group: "www-data"
+#nextcloud_mysql_root_pwd: "secret"

--- a/tasks/db_mysql.yml
+++ b/tasks/db_mysql.yml
@@ -1,7 +1,7 @@
 ---
 - name: "[mySQL] - Service is installed."
   package: "name={{ nextcloud_db_backend }}-server state=present"
-  register: db_install
+  register: nc_mysql_db_install
 
 - name: "[mySQL] - PHP module is installed."
   package: "name=php{{ php_ver }}-mysql state=present"
@@ -45,11 +45,11 @@
       login_password: "{{ nextcloud_mysql_root_pwd }}"
       login_user: root
     ignore_errors: yes
-  when: db_install.changed
+  when: nc_mysql_db_install.changed
 
 - name: "[mySQL] - Check credentials"
   stat: "path=/root/.my.cnf"
-  register: mycred
+  register: nc_mysql_mycred
 
 - block:
   - name: "[mySQL] - Make the file .my.cnf"
@@ -62,7 +62,7 @@
         [client]
         user=root
         password="{{ nextcloud_mysql_root_pwd }}"
-  when: mycred.stat.exists is defined and not mycred.stat.exists
+  when: nc_mysql_mycred.stat.exists is defined and not nc_mysql_mycred.stat.exists
 
 - name: "[mySQL] - Fix mysql binary logging for nextcloud"
   copy:

--- a/tasks/db_mysql.yml
+++ b/tasks/db_mysql.yml
@@ -12,14 +12,14 @@
 
 - block:
   - name: "[mySQL] - generate {{ nextcloud_db_backend }} root Password:"
-    set_fact: mysql_root_pwd="{{ lookup( 'password', 'nextcloud_instances/'+ nextcloud_instance_name +'/mysql_root.pwd' ) }}"
-    when: mysql_root_pwd is not defined
+    set_fact: nextcloud_mysql_root_pwd="{{ lookup( 'password', 'nextcloud_instances/'+ nextcloud_instance_name +'/mysql_root.pwd' ) }}"
+    when: nextcloud_mysql_root_pwd is not defined
 
   - name: "[mySQL] - Update {{ nextcloud_db_backend }} root password"
     mysql_user:
       name: root
       host: "{{ item }}"
-      password: "{{ mysql_root_pwd }}"
+      password: "{{ nextcloud_mysql_root_pwd }}"
       login_user: root
       login_password: ""
       check_implicit_admin: yes
@@ -34,7 +34,7 @@
     mysql_user:
       user: ""
       state: "absent"
-      login_password: "{{ mysql_root_pwd }}"
+      login_password: "{{ nextcloud_mysql_root_pwd }}"
       login_user: root
     ignore_errors: yes
 
@@ -42,7 +42,7 @@
     mysql_db:
       name: test
       state: absent
-      login_password: "{{ mysql_root_pwd }}"
+      login_password: "{{ nextcloud_mysql_root_pwd }}"
       login_user: root
     ignore_errors: yes
   when: db_install.changed
@@ -61,7 +61,7 @@
       block: |
         [client]
         user=root
-        password="{{ mysql_root_pwd }}"
+        password="{{ nextcloud_mysql_root_pwd }}"
   when: mycred.stat.exists is defined and not mycred.stat.exists
 
 - name: "[mySQL] - Fix mysql binary logging for nextcloud"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,23 +33,23 @@
 
 - name: Check Nextcloud installed
   stat: "path={{ nextcloud_webroot }}/index.php"
-  register: _nextcloud_installed
+  register: nc_nextcloud_installed
 
 - name: Downloading Nextcloud
   include: tasks/nc_download.yml
-  when: not _nextcloud_installed.stat.exists
+  when: not nc_nextcloud_installed.stat.exists
 
 - name: Check Nextcloud configuration exists.
   stat: path="{{ nextcloud_webroot }}/config/config.php"
-  register: _nextcloud_conf
+  register: nc_nextcloud_conf
 
 - name: Check Nextcloud is configured
   command: grep -q "{{ nextcloud_trusted_domain| first }}" {{ nextcloud_webroot }}/config/config.php
   failed_when: False
   changed_when: False
-  register: _nextcloud_configured
-  when: _nextcloud_conf.stat.exists
+  register: nc_nextcloud_configured
+  when: nc_nextcloud_conf.stat.exists
 
 - name: Nextcloud installation
   include: tasks/nc_installation.yml
-  when: (not _nextcloud_conf.stat.exists) or (_nextcloud_configured.rc is defined and _nextcloud_configured.rc != 0)
+  when: (not nc_nextcloud_conf.stat.exists) or (nc_nextcloud_configured.rc is defined and nc_nextcloud_configured.rc != 0)

--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -55,14 +55,14 @@
 
   - name: "[NC] - Verify config.php - check filesize"
     stat: path="{{ nextcloud_webroot }}/config/config.php"
-    register: _confsize
-    failed_when: _confsize.stat.size is undefined or _confsize.stat.size <= 100
+    register: nc_installation_confsize
+    failed_when: nc_installation_confsize.stat.size is undefined or nc_installation_confsize.stat.size <= 100
 
   - name: "[NC] - Verify config.php - php syntax check"
     command: "php -l {{ nextcloud_webroot }}/config/config.php"
-    register: _confphp
+    register: nc_installation_confphp
     changed_when: False
-    failed_when: _confphp.rc is defined and _confphp.rc != 0
+    failed_when: nc_installation_confphp.rc is defined and nc_installation_confphp.rc != 0
 
   rescue:
     - name: "[NC] - removing config.php when occ fail"
@@ -100,13 +100,13 @@
 
 - name: "[NC] - Ensure Nextcloud directories are 0750"
   command: find {{ nextcloud_data_dir }} -type d -exec chmod -c 0750 {} \;
-  register: chmod_result
-  changed_when: "chmod_result.stdout != \"\""
+  register: nc_installation_chmod_result
+  changed_when: "nc_installation_chmod_result.stdout != \"\""
 
 - name: "[NC] - Ensure Nextcloud files are 0640"
   command: find {{ nextcloud_data_dir }} -type f -exec chmod -c 0640 {} \;
-  register: chmod_result
-  changed_when: "chmod_result.stdout != \"\""
+  register: nc_installation_chmod_result
+  changed_when: "nc_installation_chmod_result.stdout != \"\""
 
 - name: "[NC] - Setting stronger directory ownership"
   file:

--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -11,8 +11,8 @@
     mode: u=rwX,g=rX,o-rwx
     recurse: yes
     state: directory
-    owner: "{{ websrv_user }}"
-    group: "{{ websrv_group }}"
+    owner: "{{ nextcloud_websrv_user }}"
+    group: "{{ nextcloud_websrv_group }}"
 
 - name: "[NC] - generate {{ nextcloud_admin_name }} password:"
   set_fact: nextcloud_admin_pwd="{{ lookup( 'password', 'nextcloud_instances/'+ nextcloud_instance_name +'/web_admin.pwd length=10' ) }}"
@@ -23,8 +23,8 @@
     path: "{{ nextcloud_webroot }}"
     state: directory
     recurse: yes
-    owner: "{{ websrv_user }}"
-    group: "{{ websrv_group }}"
+    owner: "{{ nextcloud_websrv_user }}"
+    group: "{{ nextcloud_websrv_group }}"
 
 # fix for mariadb with occ
 - set_fact: nextcloud_tmp_backend="{{ nextcloud_db_backend }}"
@@ -38,7 +38,7 @@
       path: "{{ nextcloud_webroot }}/config/config.php"
       state: absent
   - name: "[NC] - Run occ installation command"
-    become_user: "{{ websrv_user }}"
+    become_user: "{{ nextcloud_websrv_user }}"
     command: >
         php occ maintenance:install
         --database={{ nextcloud_tmp_backend }}
@@ -112,8 +112,8 @@
   file:
     path: "{{ nextcloud_webroot }}/{{ item }}/"
     recurse: yes
-    owner: "{{ websrv_user }}"
-    group: "{{ websrv_group }}"
+    owner: "{{ nextcloud_websrv_user }}"
+    group: "{{ nextcloud_websrv_group }}"
     state: directory
   with_items:
     - apps

--- a/tasks/setup_env.yml
+++ b/tasks/setup_env.yml
@@ -24,13 +24,13 @@
 - name: "[PostgreSQL] - Debian only : checking sudo."
   shell: "dpkg -l sudo"
   changed_when: False
-  register: command_result
+  register: nc_sudo_installed_result
   failed_when: False
   when: ansible_distribution == "Debian"
 
 - name: "[PostgreSQL] - rolling back to su."
   set_fact: ansible_become_method="su"
-  when: command_result is defined and command_result.rc != 0
+  when: nc_sudo_installed_result is defined and nc_sudo_installed_result.rc != 0
 
 # fix for ubuntu 14.04 with permission issue for unprivileged user :
 - name: "[NC] - Adding ACL on trusty."

--- a/tasks/tls_installed.yml
+++ b/tasks/tls_installed.yml
@@ -7,11 +7,11 @@
   # file:
     # path: "{{ nextcloud_tls_cert_file }}"
     # mode: 0644
-    # group: "{{ websrv_group }}"
+    # group: "{{ nextcloud_websrv_group }}"
 
 # - name: "[INSTALLED TLS] - check TLS key permissions"
   # file:
     # path: "{{ nextcloud_tls_cert_key_file }}"
     # mode: 0640
-    # group: "{{ websrv_group }}"
+    # group: "{{ nextcloud_websrv_group }}"
 

--- a/tasks/tls_selfsigned.yml
+++ b/tasks/tls_selfsigned.yml
@@ -16,10 +16,10 @@
   file:
     path: "{{ nextcloud_tls_cert_file }}"
     mode: 0644
-    group: "{{ websrv_group }}"
+    group: "{{ nextcloud_websrv_group }}"
 
 - name: "[selfsigned TLS] - check TLS key permissions"
   file:
     path: "{{ nextcloud_tls_cert_key_file }}"
     mode: 0640
-    group: "{{ websrv_group }}"
+    group: "{{ nextcloud_websrv_group }}"

--- a/tasks/tls_signed.yml
+++ b/tasks/tls_signed.yml
@@ -16,10 +16,10 @@
   file:
     path: "{{ nextcloud_tls_cert_file }}"
     mode: 0644
-    group: "{{ websrv_group }}"
+    group: "{{ nextcloud_websrv_group }}"
 
 - name: "[SIGNED TLS] - check TLS key permissions"
   file:
     path: "{{ nextcloud_tls_cert_key_file }}"
     mode: 0640
-    group: "{{ websrv_group }}"
+    group: "{{ nextcloud_websrv_group }}"


### PR DESCRIPTION
This PR prefixes default variables and ones that get registered during the role.

To prevent any clashes with other roles that might be using the same (partly generic) variable names.