### PR TITLE
Make travis test rolename agnostic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 script:
   # Basic role syntax check
   # Test Demo case 1
-  - ansible-playbook tests/test.yml -i tests/inventory
+  - ansible-playbook tests/test.yml -i tests/inventory -v
   # test login pages
   - curl -i -s --insecure --data "user=ncadmin&password=" https://localhost/index.php/login | egrep -q "Location:.*/apps/files/"
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,6 +2,6 @@
 - hosts: localhost
   become: true
   become_user: root
-  roles:
-   - role: install_nextcloud
+  roles: [../../]
+  vars:
      nextcloud_db_backend: "pgsql"


### PR DESCRIPTION
This is so that the test works for users that have renamed the role.