### PR TITLE
Set apache log-file in configuration

### DIFF
--- a/templates/apache2_nc.j2
+++ b/templates/apache2_nc.j2
@@ -44,6 +44,9 @@
   SSLCertificateChainFile {{ nextcloud_tls_cert_chain_file }}
 {% endif %}
 
+  ErrorLog ${APACHE_LOG_DIR}/error.log
+  CustomLog ${APACHE_LOG_DIR}/access.log combined
+
 {% if nextcloud_hsts is string %}
   <IfModule mod_headers.c>
     Header always set Strict-Transport-Security "{{ nextcloud_hsts }}"


### PR DESCRIPTION
I explicitly set the log file for the apache configuration to the acces.log and error.log to make fail2ban integration easier.
Default (depending on your distribution i guess) is other-vhosts-acces.log.
I don't know if you care, or have a different opinion here, so this is just a "take if like, decline if not"-PR.