### PR TITLE
Enable PHP OPcache

### DIFF
--- a/tasks/http_nginx.yml
+++ b/tasks/http_nginx.yml
@@ -65,7 +65,6 @@
 
 - name: "[NGINX] -  enable PHP OPcache for php.ini"
   lineinfile:
-    #path: "{{ php_dir }}/fpm/php.ini" #for ansible 2.3
     dest: "{{ php_dir }}/fpm/php.ini"
     state: present
     regexp: "{{ item.regexp }}"

--- a/tasks/http_nginx.yml
+++ b/tasks/http_nginx.yml
@@ -63,6 +63,25 @@
     # validate: "/usr/sbin/{{ php_bin }} -t #%s"
   notify: reload php-fpm
 
+- name: "[NGINX] -  enable PHP OPcache for php.ini"
+  lineinfile:
+    #path: "{{ php_dir }}/fpm/php.ini" #for ansible 2.3
+    dest: "{{ php_dir }}/fpm/php.ini"
+    state: present
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    backrefs: yes
+  with_items:
+    - { regexp: 'opcache.enable=0', line: 'opcache.enable=1' }
+    - { regexp: 'opcache.enable_cli', line: 'opcache.enable_cli=1' }
+    - { regexp: 'opcache.interned_strings_buffer', line: 'opcache.interned_strings_buffer=8' }
+    - { regexp: 'opcache.max_accelerated_files', line: 'opcache.max_accelerated_files=10000' }
+    - { regexp: 'opcache.memory_consumption', line: 'opcache.memory_consumption=128' }
+    - { regexp: 'opcache.save_comments', line: 'opcache.save_comments=1' }
+    - { regexp: 'opcache.revalidate_freq', line: 'opcache.revalidate_freq=1' }
+    # validate: "/usr/sbin/{{ php_bin }} -t #%s"
+  notify: reload php-fpm
+
 - name: "[NGINX] -  Public Diffie-Hellman Parameter are generated. This might take a while."
   command: "openssl dhparam -out {{ nextcloud_tls_dhparam }} 2048"
   args:

--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -36,7 +36,6 @@ server {
 {% endif %}
 {% endif %}
     add_header X-Content-Type-Options nosniff;
-    add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;


### PR DESCRIPTION
Hi

thank you for your role. It helps me quite a lot.
(Sorry still new to github and git. Hope this is the right way todo things.)


After installing with nginx, php-fpm the admin panel recommends to set opcache settings.
Same as in the Manual here:
https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html?highlight=opcache#enable-php-opcache

As you can see, my commit only updates those files in fpm/php.ini.
Probably apache needs it too. Don't have a test setup for apache. 