### PR TITLE
All instances of state: installed changed to state: present.

### DIFF
--- a/tasks/db_postgresql.yml
+++ b/tasks/db_postgresql.yml
@@ -2,7 +2,7 @@
 - name: "[PostgreSQL] - PostgreSQL packages are installed"
   package:
     name: "{{ item }}"
-    state: "installed"
+    state: "present"
   with_items:
     - "postgresql"
     - "php{{ php_ver }}-pgsql"

--- a/tasks/nc_download.yml
+++ b/tasks/nc_download.yml
@@ -1,10 +1,10 @@
 ---
 - name: "[NC-DL] - Unzip is installed"
-  package: name=unzip state=installed
+  package: name=unzip state=present
   when: nextcloud_archive_format == "zip"
 
 - name: "[NC-DL] - bunzip2 is installed"
-  package: name=bzip2 state=installed
+  package: name=bzip2 state=present
   when: nextcloud_archive_format == "tar.bz2"
 
 - block:

--- a/tasks/setup_env.yml
+++ b/tasks/setup_env.yml
@@ -36,5 +36,5 @@
 - name: "[NC] - Adding ACL on trusty."
   apt:
     name: acl
-    state: installed
+    state: present
   when: ansible_distribution_release == "trusty"

--- a/tests/nextcloud10_mariadb.yml
+++ b/tests/nextcloud10_mariadb.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 

--- a/tests/nextcloud10_mysql.yml
+++ b/tests/nextcloud10_mysql.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 

--- a/tests/nextcloud10_nginx.yml
+++ b/tests/nextcloud10_nginx.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 

--- a/tests/nextcloud10_psql.yml
+++ b/tests/nextcloud10_psql.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 

--- a/tests/nextcloud_mariadb.yml
+++ b/tests/nextcloud_mariadb.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 

--- a/tests/nextcloud_mysql.yml
+++ b/tests/nextcloud_mysql.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 

--- a/tests/nextcloud_nginx.yml
+++ b/tests/nextcloud_nginx.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 

--- a/tests/nextcloud_psql.yml
+++ b/tests/nextcloud_psql.yml
@@ -11,7 +11,7 @@
     - name: Install required testing packages
       package:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - curl
 


### PR DESCRIPTION
As of Ansible 2.5 'state: installed' is deprecated and will generate warnings
when used.  Used 'state: present' instead.

The warning is:
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present'
instead.. This feature will be removed in version 2.9. Deprecation warnings can
 be disabled by setting deprecation_warnings=False in ansible.cfg.