### PR TITLE
Add custom PHP version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,3 +80,5 @@ nextcloud_apps: {}
 nextcloud_websrv_user: "www-data"
 nextcloud_websrv_group: "www-data"
 #nextcloud_mysql_root_pwd: "secret"
+
+php_custom: false

--- a/tasks/setup_env.yml
+++ b/tasks/setup_env.yml
@@ -13,11 +13,11 @@
 
 - name: "[ENV] - Load environment for OS using php 5"
   include_vars: "{{ role_path }}/defaults/php5_env.yml"
-  when: ansible_distribution_release in [ "trusty", "jessie" ]
+  when: ansible_distribution_release in [ "trusty", "jessie" ] and not php_custom
 
 - name: "[ENV] - Load environment for OS using php 7.0"
   include_vars: "{{ role_path }}/defaults/php7.0_env.yml"
-  when: ansible_distribution_release in [ "xenial", "stretch" ]
+  when: ansible_distribution_release in [ "xenial", "stretch" ] and not php_custom
 
   # fix for debian not using sudo :
   # defining if sudo is installed or not


### PR DESCRIPTION
With this change one can specify their own PHP configurations. Example snippet:

```
php_version: '7.1'
php_custom: yes
php_ver: "{{ php_version }}"
php_dir: "/etc/php/{{ php_version }}"
php_bin: "php-fpm{{ php_version }}"
php_pkg_apcu: "php-apcu"
php_pkg_spe:
  - "php{{ php_version }}-imap"
  - "php{{ php_version }}-imagick"
  - "php{{ php_version }}-xml"
  - "php{{ php_version }}-zip"
  - "php{{ php_version }}-mbstring"
  - "php-redis"
```