### PR TITLE
Changed nginx template to implement changes suggested by NextCloud 14 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,13 @@ Choose between the 2 archive formats available in the repository.
 # nextcloud_full_url:
 ```
 _If you don't like rules..._
-Specify directly a full URL to the archive. The role will skip the url generation and download the archive
+Specify directly a full URL to the archive. The role will skip the url generation and download the archive. **Requires nextcloud_version_major to be set along**.
 #### Examples:
 - Download your own archive:
+  (_you **must** specify the nextcloud major version along_)
 ```YAML
 nextcloud_full_url: https://h2g2.com/42/nexcloud.zip
+nextcloud_version_major: 42
 ```
 - Choose the latest release (default):
 ```YAML

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,6 @@ nextcloud_get_latest: true # mandatory # specify if the latest archive should be
 # nextcloud_version_major: 10 # (9 | 10 | 11| ..) for releases |  for daily : (master | stable9 | stable10 | ...)
 # nextcloud_version_full: "10.0.3" # full version string
 # nextcloud_version_special: "" #  For prereleases: "RCn|beta" | for daily "YYYY-MM-DD"
-nextcloud_version_14_or_higher: true
 nextcloud_repository: "https://download.nextcloud.com/server" # Domain URL where to download Nextcloud.
 nextcloud_archive_format: "zip" # zip | tar.bz2
 # nextcloud_full_url: "https://h2g2.com/downloads/42/my_nexcloud.zip" # specify directly a full URL to the archive if you don't like rules.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ nextcloud_get_latest: true # mandatory # specify if the latest archive should be
 # nextcloud_version_major: 10 # (9 | 10 | 11| ..) for releases |  for daily : (master | stable9 | stable10 | ...)
 # nextcloud_version_full: "10.0.3" # full version string
 # nextcloud_version_special: "" #  For prereleases: "RCn|beta" | for daily "YYYY-MM-DD"
+nextcloud_version_14_or_higher: true
 nextcloud_repository: "https://download.nextcloud.com/server" # Domain URL where to download Nextcloud.
 nextcloud_archive_format: "zip" # zip | tar.bz2
 # nextcloud_full_url: "https://h2g2.com/downloads/42/my_nexcloud.zip" # specify directly a full URL to the archive if you don't like rules.

--- a/tasks/nc_download.yml
+++ b/tasks/nc_download.yml
@@ -7,6 +7,11 @@
   package: name=bzip2 state=present
   when: nextcloud_archive_format == "tar.bz2"
 
+- name: you must specify the major version
+  assert:
+    that: nextcloud_version_major is defined
+  when: nextcloud_full_url is defined
+
 - block:
   - name: "[NC-DL] - Create the download link for *latest*."
     set_fact:

--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -16,10 +16,10 @@ server {
     server_name {{ nextcloud_trusted_domain | join(' ') }};
 
 {% if not nextcloud_install_tls or not nextcloud_tls_enforce %}
-    listen 80;
+    listen 80 http2;
 {% endif %}
 {% if nextcloud_install_tls %}
-    listen 443 ssl;
+    listen 443 ssl http2;
     ssl_certificate {{ nextcloud_tls_cert_file }};
     ssl_certificate_key {{ nextcloud_tls_cert_key_file }};
     ssl_session_timeout 1d;
@@ -53,6 +53,10 @@ server {
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;
     add_header X-Permitted-Cross-Domain-Policies none;
+    add_header Referrer-Policy no-referrer;
+
+    # Remove X-Powered-By, which is an information leak
+    fastcgi_hide_header X-Powered-By;
 
     # Path to the root of your installation
     root {{ nextcloud_webroot }};
@@ -80,8 +84,13 @@ server {
     client_max_body_size 512M;
     fastcgi_buffers 64 4K;
 
-    # Disable gzip to avoid the removal of the ETag header
-    gzip off;
+    # Enable gzip but do not remove ETag headers
+    gzip on;
+    gzip_vary on;
+    gzip_comp_level 4;
+    gzip_min_length 256;
+    gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
+    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
     # Uncomment if your server is build with the ngx_pagespeed module
     # This module is currently not supported.
@@ -132,11 +141,12 @@ server {
         add_header Strict-Transport-Security "{{ nextcloud_hsts }}";
 {% endif %}
         add_header X-Content-Type-Options nosniff;
-        add_header X-Frame-Options "SAMEORIGIN";
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
         add_header X-Download-Options noopen;
         add_header X-Permitted-Cross-Domain-Policies none;
+        add_header Referrer-Policy no-referrer;
+
         # Optional: Don't log access to assets
         access_log off;
     }

--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -16,18 +16,10 @@ server {
     server_name {{ nextcloud_trusted_domain | join(' ') }};
 
 {% if not nextcloud_install_tls or not nextcloud_tls_enforce %}
-{% if nextcloud_version_14_or_higher %}
-    listen 80 http2;
-{% else %}
-    listen 80;
-{% endif %}
+    listen 80{% if nextcloud_version_14_or_higher %} http2{% endif %};
 {% endif %}
 {% if nextcloud_install_tls %}
-{% if nextcloud_version_14_or_higher %}
-    listen 443 ssl http2;
-{% else %}
-    listen 443 ssl;
-{% endif %}
+    listen 443 ssl{% if nextcloud_version_14_or_higher %} http2{% endif %};
     ssl_certificate {{ nextcloud_tls_cert_file }};
     ssl_certificate_key {{ nextcloud_tls_cert_key_file }};
     ssl_session_timeout 1d;

--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -16,10 +16,18 @@ server {
     server_name {{ nextcloud_trusted_domain | join(' ') }};
 
 {% if not nextcloud_install_tls or not nextcloud_tls_enforce %}
+{% if nextcloud_version_14_or_higher %}
     listen 80 http2;
+{% else %}
+    listen 80;
+{% endif %}
 {% endif %}
 {% if nextcloud_install_tls %}
+{% if nextcloud_version_14_or_higher %}
     listen 443 ssl http2;
+{% else %}
+    listen 443 ssl;
+{% endif %}
     ssl_certificate {{ nextcloud_tls_cert_file }};
     ssl_certificate_key {{ nextcloud_tls_cert_key_file }};
     ssl_session_timeout 1d;
@@ -84,6 +92,7 @@ server {
     client_max_body_size 512M;
     fastcgi_buffers 64 4K;
 
+{% if nextcloud_version_14_or_higher %}
     # Enable gzip but do not remove ETag headers
     gzip on;
     gzip_vary on;
@@ -91,6 +100,10 @@ server {
     gzip_min_length 256;
     gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
     gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+{% else %}
+    # Disable gzip to avoid the removal of the ETag header
+    gzip off;
+{% endif %}
 
     # Uncomment if your server is build with the ngx_pagespeed module
     # This module is currently not supported.
@@ -139,6 +152,9 @@ server {
         # have those duplicated to the ones above)
 {% if nextcloud_install_tls and nextcloud_hsts is string %}
         add_header Strict-Transport-Security "{{ nextcloud_hsts }}";
+{% endif %}
+{% if not nextcloud_version_14_or_higher %}
+        add_header X-Frame-Options "SAMEORIGIN";
 {% endif %}
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";

--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -16,10 +16,10 @@ server {
     server_name {{ nextcloud_trusted_domain | join(' ') }};
 
 {% if not nextcloud_install_tls or not nextcloud_tls_enforce %}
-    listen 80{% if nextcloud_version_14_or_higher %} http2{% endif %};
+    listen 80{% if (nextcloud_computed_major_version|int) > 13 %} http2{% endif %};
 {% endif %}
 {% if nextcloud_install_tls %}
-    listen 443 ssl{% if nextcloud_version_14_or_higher %} http2{% endif %};
+    listen 443 ssl{% if (nextcloud_computed_major_version|int) > 13 %} http2{% endif %};
     ssl_certificate {{ nextcloud_tls_cert_file }};
     ssl_certificate_key {{ nextcloud_tls_cert_key_file }};
     ssl_session_timeout 1d;
@@ -84,7 +84,7 @@ server {
     client_max_body_size 512M;
     fastcgi_buffers 64 4K;
 
-{% if nextcloud_version_14_or_higher %}
+{% if (nextcloud_computed_major_version|int) > 13 %}
     # Enable gzip but do not remove ETag headers
     gzip on;
     gzip_vary on;
@@ -145,7 +145,7 @@ server {
 {% if nextcloud_install_tls and nextcloud_hsts is string %}
         add_header Strict-Transport-Security "{{ nextcloud_hsts }}";
 {% endif %}
-{% if not nextcloud_version_14_or_higher %}
+{% if (nextcloud_computed_major_version|int) < 13 %}
         add_header X-Frame-Options "SAMEORIGIN";
 {% endif %}
         add_header X-Content-Type-Options nosniff;

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,27 @@ nextcloud_dl_file_name:
   releases: "{{['nextcloud', nextcloud_version_full]|reject('undefined')|join('-')}}"
   prereleases: "nextcloud-{{[nextcloud_version_full, nextcloud_version_special]|reject('undefined')|join()}}"
   daily: "nextcloud-{{nextcloud_version_major|d('')}}-daily-{{nextcloud_version_special|d('')}}"
+
+## finding the major version selected by the user :
+## type : string
+# the user will set either nextcloud_version_major or nextcloud_version_full
+# to pin point a major/specific version.
+# if nextcloud_version_major is set it can have 3 values:
+#   - 'master' : we just set an arbitrary high version (99)   -- used for daily
+#   - a version number [M] : here's what we need. neat !
+#   - stable[M] : just remove the 'stable' and here we go !
+#     note: There is still a case when the user could use the master branch AND specify a very old date
+#           and that whould make the computed major version inconsistent.
+#           But I'm sure at 99.99% nobody wants to do that when using the daily channel.
+# if nextcloud_version_full is set, it always have the form [Major.minor.patch] version number. (M.m.p)
+#   so the major version is the first element.
+# if both variables are set we exclude the prerelease channel that do not use the major version on the first condition.
+# if none are defined, either the user misconfigured the playbook that's calling the role
+#   and the play should fail - so we won't manage this case here -
+#   or nextcloud_get_latest is true which is the equivalent for us of using "master"
+nexcloud_computed_major_version: > # type string
+  {%- if nextcloud_version_major is defined and nextcloud_version_channel not in ['prereleases'] -%}
+  {{99 if nextcloud_version_major == 'master' else (nextcloud_version_major|regex_replace('stable')) }}
+  {%- elif nextcloud_version_full is defined -%}
+  {{ (nextcloud_version_full.split('.'))[0] }}
+  {%- else -%}99{%- endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,3 +5,4 @@ nextcloud_dl_file_name:
   releases: "{{['nextcloud', nextcloud_version_full]|reject('undefined')|join('-')}}"
   prereleases: "nextcloud-{{[nextcloud_version_full, nextcloud_version_special]|reject('undefined')|join()}}"
   daily: "nextcloud-{{nextcloud_version_major|d('')}}-daily-{{nextcloud_version_special|d('')}}"
+nextcloud_version_14_or_higher: "{% if nextcloud_get_latest or nextcloud_version_major >= 14 %}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,4 +5,3 @@ nextcloud_dl_file_name:
   releases: "{{['nextcloud', nextcloud_version_full]|reject('undefined')|join('-')}}"
   prereleases: "nextcloud-{{[nextcloud_version_full, nextcloud_version_special]|reject('undefined')|join()}}"
   daily: "nextcloud-{{nextcloud_version_major|d('')}}-daily-{{nextcloud_version_special|d('')}}"
-nextcloud_version_14_or_higher: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,4 +5,4 @@ nextcloud_dl_file_name:
   releases: "{{['nextcloud', nextcloud_version_full]|reject('undefined')|join('-')}}"
   prereleases: "nextcloud-{{[nextcloud_version_full, nextcloud_version_special]|reject('undefined')|join()}}"
   daily: "nextcloud-{{nextcloud_version_major|d('')}}-daily-{{nextcloud_version_special|d('')}}"
-nextcloud_version_14_or_higher: "{% if nextcloud_get_latest or nextcloud_version_major >= 14 %}"
+nextcloud_version_14_or_higher: true


### PR DESCRIPTION
The implemented changes were suggested by the [release notes](https://docs.nextcloud.com/server/14/admin_manual/release_notes.html) of NextCloud 14

For background compatibility I used Jinja `if` statements to only include these changes when `nextcloud_version_14_or_higher` is set to `true`. 

Since new installs will probably go with the newest version anyway, I've set its default value to `true`.

However it would be a lot more elegant if the value of this variable would be calculated based on other `nextcloud_version_...` variables.