### PR TITLE
php7.2-mcrypt removed

### DIFF
--- a/tasks/http_apache.yml
+++ b/tasks/http_apache.yml
@@ -11,7 +11,6 @@
     - "php{{ php_ver }}-json"
     - "php{{ php_ver }}-curl"
     - "php{{ php_ver }}-intl"
-    - "php{{ php_ver }}-mcrypt"
   notify: start apache
 
 - name: "[APACHE] -  Some other packages are installed."

--- a/tasks/http_nginx.yml
+++ b/tasks/http_nginx.yml
@@ -11,7 +11,6 @@
     - "php{{ php_ver }}-json"
     - "php{{ php_ver }}-curl"
     - "php{{ php_ver }}-intl"
-    - "php{{ php_ver }}-mcrypt"
   notify: [ "start nginx", "start php-fpm" ]
 
 - name: "[NGINX] -  Some other packages are installed."


### PR DESCRIPTION
php7.2-mcrypt removed

php/mcrypt deprecated in 7.1, removed in 7.2
nextcloud should work fine without it:
nextcloud/server#8265