### PR TITLE
become_user requires become:yes

### DIFF
--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -41,6 +41,7 @@
 
   - name: "[NC] - Run occ installation command"
     become_user: "{{ nextcloud_websrv_user }}"
+    become: yes
     command: >
         php occ maintenance:install
         --database={{ nextcloud_tmp_backend }}


### PR DESCRIPTION
Without this, the error is:

```
OCP\\Files\\NotFoundException in /opt/nextcloud/lib/private/Files/Node/Node.php:97
Stack trace:
#0 /opt/nextcloud/lib/private/Files/Node/Node.php(216): OC\\Files\\Node\\Node->getFileInfo()
#1 /opt/nextcloud/lib/private/Files/Node/Node.php(117): OC\\Files\\Node\\Node->getPermissions()
#2 /opt/nextcloud/lib/private/Files/Node/Folder.php(155): OC\\Files\\Node\\Node->checkPermissions(4)
#3 /opt/nextcloud/lib/private/Files/AppData/AppData.php(94): OC\\Files\\Node\\Folder->newFolder('css')
#4 /opt/nextcloud/lib/private/Files/AppData/AppData.php(114): OC\\Files\\AppData\\AppData->getAppDataFolder()
#5 /opt/nextcloud/lib/private/Template/IconsCacher.php(70): OC\\Files\\AppData\\AppData->newFolder('icons')
#6 [internal function]: OC\\Template\\IconsCacher->__construct(Object(OC\\Log), Object(OC\\Files\\AppData\\Factory), Object(OC\\URLGenerator))
#7 /opt/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php(81): ReflectionClass->newInstanceArgs(Array)
#8 /opt/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php(98): OC\\AppFramework\\Utility\\SimpleContainer->buildClass(Object(ReflectionClass))
#9 /opt/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php(119): OC\\AppFramework\\Utility\\SimpleContainer->resolve('OC\\\\Template\\\\Ico...')
#10 /opt/nextcloud/lib/private/ServerContainer.php(132): OC\\AppFramework\\Utility\\SimpleContainer->query('OC\\\\Template\\\\Ico...')
#11 /opt/nextcloud/lib/private/Server.php(969): OC\\ServerContainer->query('OC\\\\Template\\\\Ico...')
#12 /opt/nextcloud/3rdparty/pimple/pimple/src/Pimple/Container.php(118): OC\\Server->OC\\{closure}(Object(OC\\Server))
#13 /opt/nextcloud/lib/private/AppFramework/Utility/SimpleContainer.php(117): Pimple\\Container->offsetGet('OC\\\\Template\\\\SCS...')
#14 /opt/nextcloud/lib/private/ServerContainer.php(132): OC\\AppFramework\\Utility\\SimpleContainer->query('OC\\\\Template\\\\SCS...')
#15 /opt/nextcloud/lib/private/Repair.php(138): OC\\ServerContainer->query('OC\\\\Template\\\\SCS...')
#16 /opt/nextcloud/core/register_command.php(143): OC\\Repair::getRepairSteps()
#17 /opt/nextcloud/lib/private/Console/Application.php(118): require_once('/opt/nextcloud/...')
#18 /opt/nextcloud/console.php(95): OC\\Console\\Application->loadCommands(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#19 /opt/nextcloud/occ(11): require_once('/opt/nextcloud/...')
#20 {main}",
```