### PR TITLE
become_user requires become:yes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,7 @@
     args:
       chdir: "{{ nextcloud_webroot }}"
     become_user: "{{ nextcloud_websrv_user }}"
+    become: yes
     changed_when: false
     register: nc_apps_list
 

--- a/tasks/nc_apps.yml
+++ b/tasks/nc_apps.yml
@@ -16,6 +16,7 @@
 
   - name: "[ App {{nc_app_name}} ] - enable the application."
     become_user: "{{ nextcloud_websrv_user }}"
+    become: yes
     command: php occ app:enable "{{nc_app_name}}"
     args:
       chdir: "{{ nextcloud_webroot }}"
@@ -39,12 +40,14 @@
 
   - name: "[ App {{nc_app_name}} ] - enable the application."
     become_user: "{{ nextcloud_websrv_user }}"
+    become: yes
     command: php occ app:enable "{{nc_app_name}}"
     args:
       chdir: "{{ nextcloud_webroot }}"
   - block:
     - name: "[ App {{nc_app_name}} ] - Configure the application "
       become_user: "{{ nextcloud_websrv_user }}"
+      become: yes
       command: php occ config:app:set {{nc_app_name}} {{item_cfg.key}} --value="{{item_cfg.value}}"
       args:
         chdir: "{{ nextcloud_webroot }}"

--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -41,6 +41,7 @@
 
   - name: "[NC] - Run occ installation command"
     become_user: "{{ nextcloud_websrv_user }}"
+    become: yes
     command: >
         php occ maintenance:install
         --database={{ nextcloud_tmp_backend }}
@@ -79,6 +80,7 @@
 
 - name: "[NC] - Set Trusted Domains"
   become_user: "{{ nextcloud_websrv_user }}"
+  become: yes
   command: php occ config:system:set trusted_domains {{ item.0 }} --value="{{ item.1 }}"
   args:
     chdir: "{{ nextcloud_webroot }}"
@@ -86,6 +88,7 @@
 
 - name: "[NC] - Set Trusted Proxies"
   become_user: "{{ nextcloud_websrv_user }}"
+  become: yes
   command: php occ config:system:set trusted_proxies {{ item.0 }} --value="{{ item.1 }}"
   args:
     chdir: "{{ nextcloud_webroot }}"
@@ -93,6 +96,7 @@
 
 - name: "[NC] - Set Redis Server"
   become_user: "{{ nextcloud_websrv_user }}"
+  become: yes
   command: php occ config:system:set {{ item.name }} --value="{{ item.value }}"
   args:
     chdir: "{{ nextcloud_webroot }}"
@@ -102,6 +106,7 @@
 
 - name: "[NC] - Set Nextcloud settings in config.php"
   become_user: "{{ nextcloud_websrv_user }}"
+  become: yes
   shell: php occ config:system:set {{ item.name }} --value="{{ item.value }}"
   args:
     chdir: "{{ nextcloud_webroot }}"
@@ -119,6 +124,7 @@
 
 - name: "[NC] - Set Cron method to Crontab"
   become_user: "{{ nextcloud_websrv_user }}"
+  become: yes
   command: php occ background:cron
   args:
     chdir: "{{ nextcloud_webroot }}"


### PR DESCRIPTION
This was fixed everywhere

I don't understand why `become: yes` is not added at all the places. Am I missing something?