### PR TITLE
Disable the default site of apache and nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ nextcloud_websrv: "apache2"
 ```
 The http server used by nextcloud. Available values are: **apache2** or **nginx**.
 ```YAML
+nextcloud_disable_websrv_default_site: false
+```
+Disable the default site of the chosen http server. (`000-default.conf` in Apache, `default` in Nginx.)
+```YAML
 nextcloud_websrv_template: "templates/{{nextcloud_websrv}}_nc.j2"
 ```
 The jinja2 template creating the instance configuration for your webserver.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,7 @@ nextcloud_instance_name: "{{ nextcloud_trusted_domain | first }}"
 
 nextcloud_install_websrv: true
 nextcloud_websrv: "apache2" # "apache2" | "nginx"
+nextcloud_disable_websrv_default_site: false
 nextcloud_websrv_template: "templates/{{nextcloud_websrv}}_nc.j2"
 nextcloud_webroot: "/opt/nextcloud"
 nextcloud_data_dir: "/var/ncdata"

--- a/tasks/http_apache.yml
+++ b/tasks/http_apache.yml
@@ -59,4 +59,5 @@
   file:
     path: /etc/apache2/sites-enabled/000-default.conf
     state: absent
+  when: nextcloud_disable_websrv_default_site | bool
   notify: reload http

--- a/tasks/http_apache.yml
+++ b/tasks/http_apache.yml
@@ -54,3 +54,9 @@
     src: /etc/apache2/sites-available/nc_{{ nextcloud_instance_name }}.conf
     state: link
   notify: reload http
+
+- name: "[APACHE] -  Disable apache default site"
+  file:
+    path: /etc/apache2/sites-enabled/000-default.conf
+    state: absent
+  notify: reload http

--- a/tasks/http_nginx.yml
+++ b/tasks/http_nginx.yml
@@ -83,4 +83,5 @@
   file:
     path: /etc/nginx/sites-enabled/default
     state: absent
+  when: nextcloud_disable_websrv_default_site | bool
   notify: reload http

--- a/tasks/http_nginx.yml
+++ b/tasks/http_nginx.yml
@@ -78,3 +78,9 @@
     src: /etc/nginx/sites-available/nc_{{ nextcloud_instance_name }}.cnf
     state: link
   notify: reload http
+
+- name: "[NGINX] -  Disable nginx default site"
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  notify: reload http


### PR DESCRIPTION
Hi, thanks for sharing this excellent role.

I tell you that I mounted an instance on Apache with forced HTTPS (`nextcloud_tls_enforce: true`) in which everything went fine except for one detail. If I access my instance directly with the URL (`my-nextcloud.org`), I match to the default Apache site instead of my Nextcloud. Therefore I must explicitly specify the HTTPS prefix to access the site (`https://my-nextcloud.org`)

The configuration file of the Nextcloud site is generated correctly (making a permanent redirection of HTTP traffic to HTTPS), but the default Apache site (`000-default.conf`) is still enabled and traps me first.

In my opinion the solution is simply disable the default site, which is what I propose in this PR (also for Nginx).

I can't imagine a scenario in which someone wanted to keep this site enabled in production, so I did not consider it necessary add a variable to make a conditional about this task.