### PR TITLE
 Fixing 'Your web server is not properly set up to resolve "/ocm-provider/".'

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The list of domains you will use to access the same Nextcloud instance.
 ```YAML
 nextcloud_trusted_proxies: []
 ```
-The list of trusted proxies IPs if Nextcloud runs through a reverse proxy you.
+The list of trusted proxies IPs if Nextcloud runs through a reverse proxy.
 ```YAML
 nextcloud_instance_name: "{{ nextcloud_trusted_domain | first }}"
 ```

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ nextcloud_config_settings:
   - { name: 'mysql.utf8mb4', value: 'true' }
   - { name: 'updater.release.channel', value: 'production' } # production | stable | daily | beta
 ```
-Setting custom Nextcloud setting in config.php ( [Config.php Parameters Documentations](https://docs.nextcloud.com/server/12/admin_manual/configuration_server/config_sample_php_parameters.html) )
+Setting custom Nextcloud setting in config.php ( [Config.php Parameters Documentations](https://docs.nextcloud.com/server/stable/admin_manual/) )
 
 Default custom settings:
 -   **Base URL**: 'https:// {{nextcloud_instance_name}}'

--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -124,7 +124,7 @@ server {
         deny all;
     }
 
-    location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
+    location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|oc[ms]-provider/.+|core/templates/40[34])\.php(?:$|/) {
         # include fastcgi_params;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
@@ -139,7 +139,7 @@ server {
         #fastcgi_request_buffering off;
     }
 
-    location ~ ^/(?:updater|ocs-provider)(?:$|/) {
+    location ~ ^/(?:updater|oc[ms]-provider)(?:$|/) {
         try_files $uri/ =404;
         index index.php;
     }


### PR DESCRIPTION
Fixing this error:
```
There are some warnings regarding your setup.
    Your web server is not properly set up to resolve "/ocm-provider/". This is most likely related to a web server configuration that was not updated to deliver this folder directly. Please compare your configuration against the shipped rewrite rules in ".htaccess" for Apache or the provided one in the documentation for Nginx at it's documentation page. On Nginx those are typically the lines starting with "location ~" that need an update.
```

Using code from here:
https://docs.nextcloud.com/server/16/admin_manual/installation/nginx.html