### PR TITLE
*Fix* Debian does not have a "mysql-server" package

### DIFF
--- a/tasks/db_mysql.yml
+++ b/tasks/db_mysql.yml
@@ -1,17 +1,9 @@
 ---
-- name: "[mySQL] - Service is installed."
-  package:
-    name: "{{ nextcloud_db_backend }}-server"
-    state: present
-  register: nc_mysql_db_install
-  when: ansible_distribution != "Debian"
-  
 - name: "[mySQL: Debian] - Service is installed."
   package:
-    name: "default-{{ nextcloud_db_backend }}-server"
+    name: "{{ 'default-' if (ansible_distribution|lower) == 'debian' else '' }}{{ nextcloud_db_backend }}-server"
     state: present
   register: nc_mysql_db_install
-  when: ansible_distribution == "Debian"
 
 - name: "[mySQL] - Packages are installed."
   package:

--- a/tasks/db_mysql.yml
+++ b/tasks/db_mysql.yml
@@ -4,6 +4,14 @@
     name: "{{ nextcloud_db_backend }}-server"
     state: present
   register: nc_mysql_db_install
+  when: ansible_distribution != "Debian"
+  
+- name: "[mySQL: Debian] - Service is installed."
+  package:
+    name: "default-{{ nextcloud_db_backend }}-server"
+    state: present
+  register: nc_mysql_db_install
+  when: ansible_distribution == "Debian"
 
 - name: "[mySQL] - Packages are installed."
   package:


### PR DESCRIPTION
This creates a check for if the user has Debian or not.
In Debian, the package name for mysql is "default-mysql-server".