### PR TITLE
Moved configuration files to nginx conf folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
   # Install ansible
   - sudo pip install -I "ansible${ansible_version}"
   - sudo apt-get install python-netaddr
+  - sudo ansible-galaxy install nginxinc.nginx
 
 
 install:

--- a/tasks/http_nginx.yml
+++ b/tasks/http_nginx.yml
@@ -55,33 +55,21 @@
 
 - name: "[NGINX] -  php handler configuration is present."
   template:
-    dest: /etc/nginx/sites-available/php_handler.cnf
+    dest: /etc/nginx/conf.d/php_handler.conf
     src: templates/nginx_php_handler.j2
   notify: reload http
 
-- name: "[NGINX] -  php handler is enabled"
-  file:
-    path: /etc/nginx/sites-enabled/php_handler
-    src: /etc/nginx/sites-available/php_handler.cnf
-    state: link
-  notify: reload http
 
 - name: "[NGINX] -  generate Nextcloud configuration for nginx"
   template:
-    dest: /etc/nginx/sites-available/nc_{{ nextcloud_instance_name }}.cnf
+    dest: /etc/nginx/conf.d/nc_{{ nextcloud_instance_name }}.conf
     src: "{{ nextcloud_websrv_template }}"
   notify: reload http
 
-- name: "[NGINX] -  Enable Nextcloud in nginx conf"
-  file:
-    path: /etc/nginx/sites-enabled/nc_{{ nextcloud_instance_name }}
-    src: /etc/nginx/sites-available/nc_{{ nextcloud_instance_name }}.cnf
-    state: link
-  notify: reload http
 
 - name: "[NGINX] -  Disable nginx default site"
   file:
-    path: /etc/nginx/sites-enabled/default
+    path: /etc/nginx/conf.d/default.conf
     state: absent
   when: nextcloud_disable_websrv_default_site | bool
   notify: reload http

--- a/tests/nextcloud_nginx_installed.yml
+++ b/tests/nextcloud_nginx_installed.yml
@@ -1,0 +1,57 @@
+---
+- hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+    
+    - name: Install required testing packages
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - curl
+
+  roles:
+    - nginxinc.nginx
+    - ansible-nextcloud
+
+  vars:
+    nextcloud_db_backend: "mariadb"
+    nextcloud_websrv: "nginx"
+    nextcloud_apps:
+      files_external: "" #enable files_external which is already installed in nextcloud
+      calendar: "https://github.com/nextcloud/calendar/releases/download/v1.5.0/calendar.tar.gz" # download and install calendar app
+    nginx_main_template_enable: true
+    nginx_main_template:
+      template_file: nginx.conf.j2
+      conf_file_name: nginx.conf
+      conf_file_location: /etc/nginx/
+      user: www-data
+      worker_processes: auto
+      error_log:
+        location: /var/log/nginx/error.log
+        level: warn
+      worker_connections: 1024
+      http_enable: true
+      http_settings:
+        access_log_format:
+          - name: main
+            format: |-
+              '$remote_addr - $remote_user [$time_local] "$request" '
+              '$status $body_bytes_sent "$http_referer" '
+              '"$http_user_agent" "$http_x_forwarded_for"'
+        access_log_location:
+          - name: main
+            location: /var/log/nginx/access.log
+        tcp_nopush: true
+        tcp_nodelay: true
+        keepalive_timeout: 65
+        cache: false
+        rate_limit: false
+        keyval: false
+      http_global_autoindex: false
+      stream_enable: false


### PR DESCRIPTION
Depending on the nginx installation it is possible that the folders `sites-available` and `sites-enable` do not exist.
Nginx provides a folder `conf.d` in which it is possible de store configuration files.
I moved the destination from `/etc/nginx/sites-available` to `/etc/nginx/conf.d`