### PR TITLE
Package installs should not use latest

### DIFF
--- a/tasks/php_install.yml
+++ b/tasks/php_install.yml
@@ -56,7 +56,7 @@
   - name: "[INSTALL] -  Install APCu from backports."
     package:
       name: "{{ php_pkg_apcu }}"
-      state: latest
+      state: present
       default_release: trusty-backports
   when: ansible_distribution_release == "trusty"
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -9,8 +9,12 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
       changed_when: false
+
     - name: update ca-certs
-      apt: name=ca-certificates state=latest
+      apt:
+        name: ca-certificates
+        state: present
+
     - block: 
       - name: Remove default travis databases
         package:


### PR DESCRIPTION
fixed ansible lint warning:
```
[403] Package installs should not use latest
```