### PR TITLE
Add option to set TLS cache size

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ Defines various method for retrieving a TLS certificate.
   nextcloud_tls_cert_chain: /path/to/cert/chain
   # ^remote absolute path to the certificate's full chain- used only by apache - Optional
 ```
+```YAML
+nextcloud_tls_session_cache_size: 50m 
+```
+Set the size of the shared nginx TLS session cache to 50 MB.
 
 ### System configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,6 +80,7 @@ nextcloud_hsts: false # recommended >= 15552000
 # nextcloud_tls_cert_chain: /path/to/cert/chain
 # nextcloud_tls_src_cert: /path/to/cert
 # nextcloud_tls_src_cert_key: /path/to/cert/key
+nextcloud_tls_session_cache_size: 50m # in Byte or human readable size notation (g|m|k)
 
 # [APPS]
 nextcloud_apps: {}

--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -32,7 +32,7 @@ server {
     ssl_certificate {{ nextcloud_tls_cert_file }};
     ssl_certificate_key {{ nextcloud_tls_cert_key_file }};
     ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:50m;
+    ssl_session_cache shared:SSL:{{ nextcloud_tls_session_cache_size }};
     # ssl_session_tickets off;
     ssl_stapling on;
     ssl_stapling_verify on;


### PR DESCRIPTION
Generally, it might be a good idea to make the TLC cache size configurable. Addtionally, it is necessary to set this option to the same value for all sites configured in nginx, otherwise it will fail to start with
`May 12 19:44:08 sad nginx[6402]: nginx: [emerg] the size 52428800 of shared memory zone "SSL" conflicts with already declared size 10485760 in /etc/nginx/sites-enabled/nc_cloud.example.com:22
`