### PR TITLE
Fix Readme for apache TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Here 2 examples for apache and nginx (because they have slightly different confi
      nextcloud_tls_cert_method: "installed"
      nextcloud_tls_cert: "/etc/letsencrypt/live/example.com/cert.pem"
      nextcloud_tls_cert_key: "/etc/letsencrypt/live/example.com/privkey.pem"
-     nextcloud_tls_cert_chain: "/etc/letsencrypt/live/example.com/fullchain.pem"
+     nextcloud_tls_cert_chain: "/etc/letsencrypt/live/example.com/chain.pem"
 
 - hosts: nginx_server
   roles:


### PR DESCRIPTION
As specified on
https://community.letsencrypt.org/t/apache-configuration-example/2338/4

The own certificate doesn't need to be included in the chain file.

I have been using the proposed configuration for years, neither firefox nor chromium gave me any error. Yet, I ended up needing to connect to the DAV server and my client complained about invalid certificate. 

A simple attempt to connect with `gnutls-cli hostname` would already fail with invalid certificate. 

The change as suggested in the community forum solves the problem. I also tested to use the proposed nginx configuration from the readme and it works equally well on apache. It all reduces to giving the cert and the rest of the chain, or the full chain as the cert file.