### PR TITLE
Credentials save in MySQL installation

### DIFF
--- a/tasks/db_mysql.yml
+++ b/tasks/db_mysql.yml
@@ -19,6 +19,15 @@
     nextcloud_mysql_root_pwd: "{{ lookup( 'password', 'nextcloud_instances/'+ nextcloud_instance_name +'/mysql_root.pwd' ) }}"
   when: nextcloud_mysql_root_pwd is not defined
 
+- name: "[mySQL] - save {{ nextcloud_db_backend }} root password in config file"
+  ini_file:
+    path: "{{ mysql_credential_file[(ansible_os_family|lower)] }}"
+    section: client
+    option: password
+    value: "{{ nextcloud_mysql_root_pwd }}"
+  no_log: true
+  when: mysql_credential_file[(ansible_os_family|lower)] is defined
+
 # use debian default credentials to work on user root password
 - name: "[mySQL] - Update {{ nextcloud_db_backend }} root password"
   mysql_user:


### PR DESCRIPTION
- Add credentials saving in mariadb cnf file

When running the playbook the first time, the credentials are created, saved locally in a file and set on the db. But the second time, the task https://github.com/aalaesar/install_nextcloud/blob/master/tasks/db_mysql.yml#L23 will take in account a config file defined in `mysql_credential_file[(ansible_os_family|lower)]` that doesn't not have the generated password (or a provided one via `nextcloud_mysql_root_pwd`) thus failing the playbook.

This task will ensure that the password is set in the same file used to connect to the database.