### PR TITLE
Fix: Remove assets directory

### DIFF
--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -162,7 +162,6 @@
     state: directory
   with_items:
     - apps
-    - assets
     - config
     - themes
     - updater


### PR DESCRIPTION
I've removed assets directory, because in newer versions it causes a problem with updater.
It was removed from source quite long time ago and it's not used anymore.
Reference:
* https://github.com/nextcloud/server/issues/2610#issuecomment-266275947
* https://github.com/nextcloud/updater/issues/23
* https://help.nextcloud.com/t/the-following-extra-files-have-been-found-assets/21026