### PR TITLE
Move the installation of the PHP database clients to php_install

### DIFF
--- a/tasks/db_mysql.yml
+++ b/tasks/db_mysql.yml
@@ -21,7 +21,6 @@
     state: present
   vars:
     nc_mysql_deps:
-      - "php{{ php_ver }}-mysql"
       - "python3-pymysql"
 
 - name: "[mySQL] - Ensure MySQL is started and enabled on boot."

--- a/tasks/db_postgresql.yml
+++ b/tasks/db_postgresql.yml
@@ -6,7 +6,6 @@
   vars:
     pg_deps:
       - "postgresql"
-      - "php{{ php_ver }}-pgsql"
       - "python3-psycopg2"
 
 - name: "[PostgreSQL] - nextcloud role is created."

--- a/tasks/php_install.yml
+++ b/tasks/php_install.yml
@@ -45,6 +45,18 @@
   with_items:
     - "{{ php_pkg_spe }}"
 
+- name: "[INSTALL - PHP Database client - MySQL."
+  ansible.builtin.package:
+    name: "php{{ php_ver }}-mysql"
+    state: present
+  when: (nextcloud_db_backend == "mysql") or (nextcloud_db_backend == "mariadb")
+
+- name: "[INSTALL - PHP Database client - PostgreSQL."
+  ansible.builtin.package:
+    name: "php{{ php_ver }}-pgsql"
+    state: present
+  when: (nextcloud_db_backend == "pgsql")
+
 - name: "[INSTALL] -  APCu is installed."
   ansible.builtin.package:
     name: "{{ php_pkg_apcu }}"


### PR DESCRIPTION
Moved the installation of the PHP Database clients to php_install.yml instead of the db installation, before when nextcloud_install_db is set to false the PHP Database clients are not installed.

This is common when you use an external database server.