### PR TITLE
Set crontab 10 minutes instead of 15, because of warning message

### DIFF
--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -132,7 +132,7 @@
     - name: "[NC] - Install Cronjob"
       ansible.builtin.cron:
         name: "Nextcloud Cronjob"
-        minute: "*/15"
+        minute: "*/10"
         user: "{{ nextcloud_websrv_user }}"
         job: "php {{ nextcloud_webroot }}/cron.php"
         cron_file: "nextcloud"


### PR DESCRIPTION
Changed the cron schedule to 10 minutes instead of 15 minutes, when the crontab has not run for more then 10 minutes it creates a warning in Nextcloud (see the screenshot below).

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/7331314/196257025-26e1bb5b-d704-49c3-a2cb-274d60c9e748.png">
