### PR TITLE
Added quotes around occ installation command arguments

### DIFF
--- a/tasks/nc_installation.yml
+++ b/tasks/nc_installation.yml
@@ -40,14 +40,14 @@
       become: true
       ansible.builtin.command: >
           php occ maintenance:install
-          --database={{ nextcloud_tmp_backend }}
-          --database-host={{ nextcloud_db_host }}
-          --database-name={{ nextcloud_db_name }}
-          --database-user={{ nextcloud_db_admin }}
-          --database-pass={{ nextcloud_db_pwd }}
-          --admin-user={{ nextcloud_admin_name }}
-          --admin-pass={{ nextcloud_admin_pwd }}
-          --data-dir={{ nextcloud_data_dir }}
+          --database="{{ nextcloud_tmp_backend }}"
+          --database-host="{{ nextcloud_db_host }}"
+          --database-name="{{ nextcloud_db_name }}"
+          --database-user="{{ nextcloud_db_admin }}"
+          --database-pass="{{ nextcloud_db_pwd }}"
+          --admin-user="{{ nextcloud_admin_name }}"
+          --admin-pass="{{ nextcloud_admin_pwd }}"
+          --data-dir="{{ nextcloud_data_dir }}"
       args:
         chdir: "{{ nextcloud_webroot }}"
         creates: "{{ nextcloud_webroot }}/config/config.php"


### PR DESCRIPTION
I got the error "Too many arguments" during the task "[NC] - Run occ installation command]" because one of my custom variables contained a whitespace. So I added quotes around every argument, and it passed.