### PR TITLE
Bump yamllint action to remove deprecation warning

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run yaml-lint
-        uses: ibiqlik/action-yamllint@v3.1.0
+        uses: ibiqlik/action-yamllint@v3.1.1
         with:
           config_file: .yamllint.yml
           format: github


### PR DESCRIPTION
Yamllint started showing deprecation warning from external library. https://github.com/aalaesar/install_nextcloud/actions/runs/3357145607
I just bumped version of `yamllint` Github Action which solved this issue.