### PR TITLE
Remove unsuported distros from before 2017

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,16 +11,14 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
-        - bionic
-        - focal
         - jammy
+        - focal
+        - bionic
 
     - name: Debian
       versions:
-        - stretch
-        - buster
         - bullseye
+        - buster
 
   galaxy_tags:
     - nextcloud


### PR DESCRIPTION
Ubuntu Xenial is from 16.04 and Debian Stretch is also from 2017, both no longer supported.