### PR TITLE
Add reviewers poll

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aalaesar @staticdev @wiktor2200


### PR DESCRIPTION
This PR is a suggestion to add me and @wiktor2200 if he agrees and if @aalaesar also agrees. This would make merging of PRs more dynamic as I am thinking of bringing more improvements in Nextcloud configuration in the upcoming days.

Github suggests adding a CODEOWNERS file with the list of reviewer reponsible for parts of the code.
Details of how CODEOWNERS file works: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file