### PR TITLE
Increase php memory_limit to 768M

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Set the size of the shared nginx TLS session cache to 50 MB.
 Install and use a custom version for PHP instead of the default one:
 
 ```yaml
-php_ver: '7.1'
+php_ver: '8.1'
 php_dir: "/etc/php/{{ php_ver }}"
 php_bin: "php-fpm{{ php_ver }}"
 php_pkg_apcu: "php-apcu"
@@ -452,7 +452,7 @@ php_pkg_spe:
   - "php{{ php_ver }}-mbstring"
   - "php-redis"
 php_socket: "/run/php/{{ php_ver }}-fpm.sock"
-php_memory_limit: 512M
+php_memory_limit: 768M
 ```
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ php_bin: "{{ php_config_ref[php_ver | replace('.', '_')].php_bin | d(php_config_
 php_pkg_apcu: "{{ php_config_ref[php_ver | replace('.', '_')].php_pkg_apcu | d(php_config_ref.defaults.php_pkg_apcu) }}"
 php_pkg_spe: "{{ php_config_ref[php_ver | replace('.', '_')].php_pkg_spe | d(php_config_ref.defaults.php_pkg_spe) }}"
 php_socket: "{{ php_config_ref[php_ver | replace('.', '_')].php_socket | d(php_config_ref.defaults.php_socket) }}"
-php_memory_limit: 512M
+php_memory_limit: 768M
 
 # [NEXTCLOUD CONFIG]
 nextcloud_trusted_domain:


### PR DESCRIPTION
I've just installed fresh Nextcloud 25.0.2 and with default role's values it's getting error: `The PHP memory limit is below the recommended value of 512MB.`
Current default was 512M, so I've changed it to 768M (added 256M), which solved this issue.
@aalaesar @staticdev What do you think about changing default to new value?