### PR TITLE
Fix installation without websrv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ bh_unicode_properties.cache
 # Sublime-github package stores a github token in this file
 # https://packagecontrol.io/packages/sublime-github
 GitHub.sublime-settings
+
+# test credentials
+/molecule/default/nextcloud_instances

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,9 +5,13 @@
   ansible.builtin.include_tasks: ./setup_env.yml
   tags: always
 
-- name: "Install required packages"
+- name: "Install PHP packages"
   ansible.builtin.include_tasks: php_install.yml
   tags: always
+
+- name: Install web server packages
+  when: nextcloud_install_websrv
+  ansible.builtin.include_tasks: ./websrv_install.yml
 
 - name: Install certificates
   when: nextcloud_install_tls

--- a/tasks/php_install.yml
+++ b/tasks/php_install.yml
@@ -6,7 +6,7 @@
   with_items:
     - imagemagick
     - smbclient
-    - "php-fpm"
+    - "php{{ php_ver }}-fpm"
     - "php{{ php_ver }}-gd"
     - "php{{ php_ver }}-ldap"
     - "php{{ php_ver }}-imap"

--- a/tasks/php_install.yml
+++ b/tasks/php_install.yml
@@ -6,6 +6,7 @@
   with_items:
     - imagemagick
     - smbclient
+    - "php-fpm"
     - "php{{ php_ver }}-gd"
     - "php{{ php_ver }}-ldap"
     - "php{{ php_ver }}-imap"

--- a/tasks/php_install.yml
+++ b/tasks/php_install.yml
@@ -1,10 +1,9 @@
 ---
-- name: "[INSTALL] -  Required and recommended packages are installed."
+- name: "[INSTALL] - Required and recommended packages are installed."
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
   with_items:
-    - "{{ nextcloud_websrv }}"
     - imagemagick
     - smbclient
     - "php{{ php_ver }}-gd"
@@ -13,30 +12,13 @@
     - "php{{ php_ver }}-curl"
     - "php{{ php_ver }}-intl"
   notify:
-    - Start http
+    - Start php-fpm
 
 - name: "[INSTALL] - php-json is installed (PHP < 8)"
   ansible.builtin.package:
     name: "php{{ php_ver }}-json"
     state: present
   when: php_ver is version("8", "<")
-
-- name: "[INSTALL] -  Apache Required package is installed."
-  ansible.builtin.package:
-    name: "libapache2-mod-php{{ php_ver }}"
-    state: present
-  when: nextcloud_websrv == "apache2"
-  notify:
-    - Start http
-
-- name: "[INSTALL] -  NGINX Required package is installed."
-  ansible.builtin.package:
-    name: "php{{ php_ver }}-fpm"
-    state: present
-  when: nextcloud_websrv == "nginx"
-  notify:
-    - Start http
-    - Start php-fpm
 
 - name: "[INSTALL] -  PHP extra Packages are installed."
   ansible.builtin.package:

--- a/tasks/php_install.yml
+++ b/tasks/php_install.yml
@@ -12,6 +12,7 @@
     - "php{{ php_ver }}-imap"
     - "php{{ php_ver }}-curl"
     - "php{{ php_ver }}-intl"
+    - "php{{ php_ver }}-bz2"
   notify:
     - Start php-fpm
 

--- a/tasks/websrv_install.yml
+++ b/tasks/websrv_install.yml
@@ -6,7 +6,7 @@
   with_items:
     - "{{ nextcloud_websrv }}"
 
-- name: "[INSTALL] - Apache Required package is installed."
+- name: "[INSTALL] - Apache required package is installed."
   ansible.builtin.package:
     name: "libapache2-mod-php{{ php_ver }}"
     state: present
@@ -15,7 +15,7 @@
     - Start http
     - Reload php-fpm
 
-- name: "[INSTALL] - NGINX Required package is installed."
+- name: "[INSTALL] - NGINX required package is installed."
   ansible.builtin.package:
     name: "php{{ php_ver }}-fpm"
     state: present

--- a/tasks/websrv_install.yml
+++ b/tasks/websrv_install.yml
@@ -1,0 +1,25 @@
+---
+- name: "[INSTALL] - Web server is installed."
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ nextcloud_websrv }}"
+
+- name: "[INSTALL] - Apache Required package is installed."
+  ansible.builtin.package:
+    name: "libapache2-mod-php{{ php_ver }}"
+    state: present
+  when: nextcloud_websrv == "apache2"
+  notify:
+    - Start http
+    - Reload php-fpm
+
+- name: "[INSTALL] - NGINX Required package is installed."
+  ansible.builtin.package:
+    name: "php{{ php_ver }}-fpm"
+    state: present
+  when: nextcloud_websrv == "nginx"
+  notify:
+    - Start http
+    - Reload php-fpm


### PR DESCRIPTION
This PR fixes installation with `nextcloud_install_websrv: false` option. Currently, `php_install` always installs the webserver without taking the option into account.