### PR TITLE
test(lint): Add lint step to molecule.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          python3 -m pip install --constraint=.github/workflows/constraints.txt ansible molecule[lint,docker] docker netaddr ansible-lint
+          python3 -m pip install --constraint=.github/workflows/constraints.txt ansible molecule[docker] docker netaddr
 
       # See: https://github.com/geerlingguy/ansible-role-mysql/issues/422
       - name: Disable AppArmor (only Debian 10).
@@ -58,6 +58,7 @@ jobs:
       - name: Run Molecule tests
         run: molecule test
         env:
+          TEST_RUN_MOLECULE_LINT: false
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          python3 -m pip install --constraint=.github/workflows/constraints.txt ansible molecule[docker] docker netaddr
+          python3 -m pip install --constraint=.github/workflows/constraints.txt ansible molecule[lint,docker] docker netaddr ansible-lint
 
       # See: https://github.com/geerlingguy/ansible-role-mysql/issues/422
       - name: Disable AppArmor (only Debian 10).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Run Molecule tests
         run: molecule test
         env:
-          TEST_RUN_MOLECULE_LINT: false
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
           MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
+        args: ["-c=.yamllint.yml", "."]
+  - repo: https://github.com/ansible-community/ansible-lint.git
+    rev: v6.8.0
+    hooks:
+      - id: ansible-lint
+        files: \.(yaml|yml)$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+## How to contribute to this ansible role
+### Install 'pre-commit' dependency
+
+To enable automatic checks (like code linting) beforey each commit it is advised to install ***pre-commit***:
+
+Install it to your environment: 
+
+`~/ansible_nextcloud$ pip install pre-commit` (for more options see [here](https://pre-commit.com/#installation))
+
+Enable pre-commit within the repo: 
+
+`~/ansible_nextcloud$ pre-commit install`
+
+(Optional) Run complete check once: 
+
+`~/ansible_nextcloud$ pre-commit run --all-files`

--- a/README.md
+++ b/README.md
@@ -633,6 +633,12 @@ He can run the role with the following variables to install Nextcloud accordingl
             wopi_url: 'https://office.example.tld'
 ```
 
+## Contributing
+
+We encourage you to contribute to this role! Please check out the
+[contributing guide](CONTRIBUTING.md) for guidelines about how to proceed.
+
 ## License
 
-BSD
+BSD 
+

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ provisioner:
     converge: "${MOLECULE_NC:-latest}-converge.yml"
 verifier:
   name: ansible
-#lint: |
-#  set -e
-#  yamllint .
-#  ansible-lint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,10 +19,3 @@ provisioner:
     converge: "${MOLECULE_NC:-latest}-converge.yml"
 verifier:
   name: ansible
-lint: |
-  set -e
-  echo "Molecule linting requested: ${TEST_RUN_MOLECULE_LINT}"
-  if [ -z "${TEST_RUN_MOLECULE_LINT}" ] || [ "${TEST_RUN_MOLECULE_LINT}" = true  ]; then
-    yamllint .
-    ansible-lint
-  fi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,5 +21,8 @@ verifier:
   name: ansible
 lint: |
   set -e
-  yamllint .
-  ansible-lint
+  echo "Molecule linting requested: ${TEST_RUN_MOLECULE_LINT}"
+  if [ -z "${TEST_RUN_MOLECULE_LINT}" ] || [ "${TEST_RUN_MOLECULE_LINT}" = true  ]; then
+    yamllint .
+    ansible-lint
+  fi


### PR DESCRIPTION
This lint step enables tests to fail locally before submitting code to
the remote repo where github actions will fail because of linting errors.
---
On the local machine yamllint as well as ansible-lint need to be installed. Like so:
python3 -m pip install molecule[lint,<more packages>] ansible-lint