### PR TITLE
Cleanup unnecessary php module params

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,7 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt ansible
 
       - name: Trigger a new import on Galaxy.
-        run: |
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_TOKEN }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+        run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_TOKEN }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt ansible
 
       - name: Trigger a new import on Galaxy.
-        run: ansible-galaxy role import --branch main --api-key ${{ secrets.GALAXY_TOKEN }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+        run: |
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_TOKEN }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5

--- a/README.md
+++ b/README.md
@@ -459,7 +459,6 @@ Install and use a custom version for PHP instead of the default one:
 php_ver: '8.1'
 php_dir: "/etc/php/{{ php_ver }}"
 php_bin: "php-fpm{{ php_ver }}"
-php_pkg_apcu: "php-apcu"
 php_pkg_spe:
   - "php{{ php_ver }}-imap"
   - "php{{ php_ver }}-imagick"

--- a/README.md
+++ b/README.md
@@ -465,7 +465,6 @@ php_pkg_spe:
   - "php{{ php_ver }}-xml"
   - "php{{ php_ver }}-zip"
   - "php{{ php_ver }}-mbstring"
-  - "php-redis"
 php_socket: "/run/php/{{ php_ver }}-fpm.sock"
 php_memory_limit: 512M
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,6 @@ php_pkg_spe:
   - "php{{ php_ver }}-gmp"
   - "php{{ php_ver }}-imagick"
   - "php{{ php_ver }}-mbstring"
-  - "php{{ php_ver }}-redis"
   - "php{{ php_ver }}-xml"
   - "php{{ php_ver }}-zip"
 php_socket: "/run/php/php{{ php_ver }}-fpm.sock"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,6 @@ php_install_external_repos: true
 php_ver: "8.1"
 php_dir: "/etc/php/{{ php_ver }}"
 php_bin: "php-fpm{{ php_ver }}"
-php_pkg_apcu: "php{{ php_ver }}-apcu"
 php_pkg_spe:
   - "php{{ php_ver }}-bcmath"
   - "php{{ php_ver }}-gmp"

--- a/tasks/php_install.yml
+++ b/tasks/php_install.yml
@@ -44,5 +44,5 @@
 
 - name: "[PHP] - APCu is installed."
   ansible.builtin.package:
-    name: "{{ php_pkg_apcu }}"
+    name: "php{{ php_ver }}-apcu"
     state: present

--- a/tasks/redis_server.yml
+++ b/tasks/redis_server.yml
@@ -1,11 +1,12 @@
 ---
 - name: "[REDIS] -  Required packages are installed."
   ansible.builtin.package:
-    name: "{{ redix_deps + php_pkg_spe }}"
+    name: "{{ redis_deps }}"
     state: present
   vars:
-    redix_deps:
+    redis_deps:
       - redis-server
+      - "php{{ php_ver }}-redis"
   notify: Start redis
 
 - name: "[REDIS] -  Redis configuration is present."


### PR DESCRIPTION
* For our target OSs it will always be "php{{ php_ver }}-apcu" like the rest of packages on https://github.com/aalaesar/install_nextcloud/blob/main/tasks/php_install.yml#L16
* Fix typo of redix instead of redis
* php{{ php_ver }}-redis is the needed dependency for redis, simplified by removing from php_pkg_spe