### PR TITLE
update ansible-lint to 6.11 for pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: yamllint
         args: ["-c=.yamllint.yml", "."]
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v6.8.0
+    rev: v6.11.0
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$


### PR DESCRIPTION
ansible-lint 6.8 behave differently than CI locally for some reason. with ansible 6.11 (same version as latest release of the github action) this is fixed now