### PR TITLE
Add pre-commit update action

### DIFF
--- a/.github/precommit-update.yml
+++ b/.github/precommit-update.yml
@@ -1,0 +1,25 @@
+name: Pre-commit auto-update
+
+on:
+  # every day at midnight
+  schedule:
+    - cron: "0 0 * * *"
+
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: actions/setup-python@v2
+      
+      - uses: browniebroke/pre-commit-autoupdate-action@main
+      
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-hooks
+          title: Update pre-commit hooks
+          commit-message: "chore: update pre-commit hooks"
+          body: Update versions of pre-commit hooks to latest version.

--- a/.github/workflows/precommit-update.yml
+++ b/.github/workflows/precommit-update.yml
@@ -1,21 +1,21 @@
+---
 name: Pre-commit auto-update
 
-on:
+"on":
   # every day at midnight
   schedule:
     - cron: "0 0 * * *"
 
-
 jobs:
-  auto-update:
+  pre-commit-auto-update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      
+
       - uses: actions/setup-python@v2
-      
+
       - uses: browniebroke/pre-commit-autoupdate-action@main
-      
+
       - uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi @aalaesar  @staticdev! I've added github action for pre-commit update to mitigate issues like: #207 
It's based on example from here: https://github.com/browniebroke/pre-commit-autoupdate-action

It requires a token: `token: ${{ secrets.GITHUB_TOKEN }}` for pull request creation, could you help with that?